### PR TITLE
Fix: Some broken animations

### DIFF
--- a/Animations/include/animation/Animation.h
+++ b/Animations/include/animation/Animation.h
@@ -263,7 +263,7 @@ namespace MathAnim
 		float timeWidth;
 		float tValue;
 
-		void render(const BBox& bbox) const;
+		void render(const AnimObject& parent) const;
 		void serialize(nlohmann::json& memory) const;
 		static Circumscribe deserialize(const nlohmann::json& j, uint32 version);
 		static Circumscribe createDefault();

--- a/Animations/include/animation/Animation.h
+++ b/Animations/include/animation/Animation.h
@@ -429,13 +429,18 @@ namespace MathAnim
 		Vec2 size;
 		ImageFilterMode filterMode;
 		ImageRepeatMode repeatMode;
+		bool isLoadingImage;
 
 		void setFilepath(const char* str, size_t strLength);
 		void setFilepath(const std::string& str);
 		void serialize(nlohmann::json& j) const;
 		void free();
 
-		void init(AnimationManagerData* am, AnimObjId parentId);
+		// NOTE: This update function is just used to check if it's
+		// in the middle of parsing loading the image.
+		void update(AnimationManagerData* am, AnimObjId parentId);
+
+		void init();
 		void reInit(AnimationManagerData* am, AnimObject* obj, bool resetSize = false);
 
 		TextureLoadOptions getLoadOptions() const;

--- a/Animations/include/animation/Animation.h
+++ b/Animations/include/animation/Animation.h
@@ -201,8 +201,8 @@ namespace MathAnim
 
 	struct MoveToData
 	{
-		Vec2 source;
-		Vec2 target;
+		Vec3 source;
+		Vec3 target;
 		AnimObjId object;
 
 		void serialize(nlohmann::json& j) const;

--- a/Animations/include/animation/AnimationManager.h
+++ b/Animations/include/animation/AnimationManager.h
@@ -66,6 +66,9 @@ namespace MathAnim
 		std::vector<AnimObjId> getChildren(const AnimationManagerData* am, AnimObjId obj);
 		AnimObjId getNextSibling(const AnimationManagerData* am, AnimObjId obj);
 
+		void setRenderAllBoundingBoxes(AnimationManagerData* am, bool shouldRender);
+		void renderAllBoundingBoxes(const AnimationManagerData* am);
+
 		void serialize(const AnimationManagerData* am, nlohmann::json& j);
 		void deserialize(AnimationManagerData* am, const nlohmann::json& j, int currentFrame, uint32 versionMajor, uint32 versionMinor);
 		void sortAnimations(AnimationManagerData* am);

--- a/Animations/include/core/Serialization.hpp
+++ b/Animations/include/core/Serialization.hpp
@@ -126,7 +126,12 @@ do { \
   const std::string& str = j.contains(#prop) && !j[#prop].is_null() ? j[#prop] : "Undefined"; \
   (obj)->##prop##Length = (uint32)str.length(); \
   (obj)->prop = (char*)g_memory_allocate(sizeof(char) * ((obj)->##prop##Length + 1)); \
-  g_memory_copyMem((obj)->prop, (void*)str.c_str(), sizeof(char) * ((obj)->##prop##Length + 1)); \
+  g_memory_copyMem(\
+    (obj)->prop,\
+    sizeof(char) * ((obj)->##prop##Length + 1),\
+    (void*)str.c_str(),\
+    sizeof(char) * ((obj)->##prop##Length + 1)\
+  ); \
 } while(false)
 
 #define DESERIALIZE_NULLABLE_U8_CSTRING(obj, prop, j) \
@@ -134,7 +139,12 @@ do { \
   const std::string& str = j.contains(#prop) && !j[#prop].is_null() ? j[#prop] : "Undefined"; \
   (obj)->##prop##Length = (uint32)str.length(); \
   (obj)->prop = (uint8*)g_memory_allocate(sizeof(uint8) * ((obj)->##prop##Length + 1)); \
-  g_memory_copyMem((obj)->prop, (void*)str.c_str(), sizeof(uint8) * ((obj)->##prop##Length + 1)); \
+  g_memory_copyMem(\
+    (obj)->prop,\
+    sizeof(uint8) * ((obj)->##prop##Length + 1),\
+    (void*)str.c_str(),\
+    sizeof(uint8) * ((obj)->##prop##Length + 1)\
+  ); \
 } while(false)
 
 #define DESERIALIZE_PROP(obj, prop, j, defaultValue) \

--- a/Animations/include/editor/Gizmos.h
+++ b/Animations/include/editor/Gizmos.h
@@ -34,7 +34,7 @@ namespace MathAnim
 		const char* getVisualModeStr();
 		GizmoType getVisualMode();
 
-		ImGuiDataEx<Vec3> translateGizmo(const char* gizmoName, Vec3* position);
+		ImGuiDataEx<Vec3> translateGizmo(const char* gizmoName, Vec3* position, bool drawCubeVisualization = false);
 		ImGuiDataEx<Vec3> rotateGizmo(const char* gizmoName, const Vec3& gizmoPosition, Vec3* rotation);
 		ImGuiDataEx<Vec3> scaleGizmo(const char* gizmoName, const Vec3& gizmoPosition, Vec3* scale);
 	}

--- a/Animations/include/editor/UndoSystem.h
+++ b/Animations/include/editor/UndoSystem.h
@@ -21,8 +21,6 @@ namespace MathAnim
 
 	enum class Vec2PropType : uint8
 	{
-		// MoveTo
-		MoveToTargetPos = 0,
 		// Scale
 		AnimateScaleTarget,
 	};
@@ -47,6 +45,8 @@ namespace MathAnim
 		ModifyAnimationVec3Target,
 		// Axis
 		AxisAxesLength,
+		// Animations
+		MoveToTargetPos
 	};
 
 	enum class Vec4PropType : uint8

--- a/Animations/include/editor/panels/DebugPanel.h
+++ b/Animations/include/editor/panels/DebugPanel.h
@@ -3,11 +3,13 @@
 
 namespace MathAnim
 {
+	struct AnimationManagerData;
+
 	namespace DebugPanel
 	{
 		void init();
 
-		void update();
+		void update(AnimationManagerData* am);
 
 		void free();
 	}

--- a/Animations/include/editor/panels/ErrorPopups.h
+++ b/Animations/include/editor/panels/ErrorPopups.h
@@ -13,6 +13,8 @@ namespace MathAnim
 		void popupSvgImportError();
 
 		void popupMissingFileError(const std::string& filename, const std::string& additionalMessage = "");
+
+		void popupTextureLoadError(const std::string& textureName, const std::string& errorMessage);
 	}
 }
 

--- a/Animations/include/editor/panels/SceneHierarchyPanel.h
+++ b/Animations/include/editor/panels/SceneHierarchyPanel.h
@@ -19,7 +19,7 @@ namespace MathAnim
 		void deleteAnimObject(const AnimObject& animObject);
 
 		void serialize(nlohmann::json& memory);
-		void deserialize(RawMemory& memory);
+		void deserialize(const nlohmann::json& memory);
 
 		bool mouseIsHovered();
 	};

--- a/Animations/include/renderer/Renderer.h
+++ b/Animations/include/renderer/Renderer.h
@@ -75,7 +75,7 @@ namespace MathAnim
 		// ----------- 2D stuff ----------- 
 		// TODO: Switch to using this when drawing completed objects to potentially
 		// batch draw calls together and improve performance
-		void drawSquare(const Vec2& start, const Vec2& size);
+		void drawSquare(const Vec2& start, const Vec2& size, const glm::mat4& transform = glm::identity<glm::mat4>());
 		void drawFilledQuad(const Vec2& start, const Vec2& size, AnimObjId objId = NULL_ANIM_OBJECT);
 		void drawTexturedQuad(const Texture& texture, const Vec2& size, const Vec2& uvMin, const Vec2& uvMax, const Vec4& color, AnimObjId objId, const glm::mat4& transform = glm::identity<glm::mat4>());
 		void drawFilledTri(const Vec2& p0, const Vec2& p1, const Vec2& p2, AnimObjId objId = NULL_ANIM_OBJECT);

--- a/Animations/include/renderer/TextureCache.h
+++ b/Animations/include/renderer/TextureCache.h
@@ -44,6 +44,7 @@ namespace MathAnim
 		});
 
 		const Texture& getTexture(TextureHandle textureHandle);
+		bool isTextureLoaded(TextureHandle textureHandle);
 
 		void free();
 	}

--- a/Animations/include/svg/Svg.h
+++ b/Animations/include/svg/Svg.h
@@ -88,6 +88,7 @@ namespace MathAnim
 		Path* paths;
 		int numPaths;
 		float approximatePerimeter;
+		Vec2 size;
 		BBox bbox;
 		Vec2 _cursor;
 		Vec4 fillColor;
@@ -97,7 +98,7 @@ namespace MathAnim
 
 		void normalize();
 		void calculateApproximatePerimeter();
-		void calculateBBox();
+		void calculateSize();
 		void calculateMd5(const RawMemory& b64Path);
 		void finalize();
 		void finalizeWithB64(const RawMemory& b64String);
@@ -127,6 +128,7 @@ namespace MathAnim
 		SvgObject* objects;
 		Vec2* objectOffsets;
 		int numObjects;
+		Vec2 size;
 		BBox bbox;
 
 		void normalize();

--- a/Animations/include/utils/LRUCache.hpp
+++ b/Animations/include/utils/LRUCache.hpp
@@ -76,8 +76,7 @@ namespace MathAnim
 
 		void insert(const Key& key, const Value& value)
 		{
-			LRUCacheEntry<Key, Value>* newEntry = (LRUCacheEntry<Key, Value>*)g_memory_allocate(sizeof(LRUCacheEntry<Key, Value>));
-			new(newEntry)LRUCacheEntry<Key, Value>();
+			auto* newEntry = g_memory_new LRUCacheEntry<Key, Value>();
 
 			*newEntry = {};
 			newEntry->data = value;
@@ -135,8 +134,7 @@ namespace MathAnim
 
 				// Free the memory now and get rid of this entry
 				indexLookup.erase(entryToEvictIter);
-				entryToEvict->~LRUCacheEntry<Key, Value>();
-				g_memory_free(entryToEvict);
+				g_memory_delete(entryToEvict);
 				return true;
 			}
 			else

--- a/Animations/src/animation/Animation.cpp
+++ b/Animations/src/animation/Animation.cpp
@@ -2558,7 +2558,8 @@ namespace MathAnim
 		// TODO: Render and handle 2D gizmo logic based on edit mode
 		std::string gizmoName = "Move_To_" + std::to_string(anim->id);
 		Vec3 tmp = anim->as.moveTo.target;
-		if (auto res = GizmoManager::translateGizmo(gizmoName.c_str(), &tmp);
+
+		if (auto res = GizmoManager::translateGizmo(gizmoName.c_str(), &tmp, true);
 			res.editState != EditState::NotEditing)
 		{
 			anim->as.moveTo.target = tmp;

--- a/Animations/src/animation/Animation.cpp
+++ b/Animations/src/animation/Animation.cpp
@@ -1068,12 +1068,12 @@ namespace MathAnim
 		if (strLength != this->scriptFilepathLength)
 		{
 			this->scriptFilepath = (char*)g_memory_realloc(this->scriptFilepath, sizeof(char) * (strLength + 1));
+			this->scriptFilepathLength = strLength;
 			g_logger_assert(this->scriptFilepath != nullptr, "Allocation failed. Out of memory.");
 		}
 
-		g_memory_copyMem((void*)this->scriptFilepathLength, (void*)str, sizeof(char) * strLength);
+		g_memory_copyMem((void*)this->scriptFilepath, sizeof(char) * this->scriptFilepathLength, (void*)str, sizeof(char) * strLength);
 		this->scriptFilepath[strLength] = '\0';
-		this->scriptFilepathLength = strLength;
 	}
 
 	void ScriptObject::setFilepath(const std::string& str)
@@ -1155,7 +1155,7 @@ namespace MathAnim
 			g_logger_assert(this->imageFilepath != nullptr, "Allocation failed. Out of memory.");
 		}
 
-		g_memory_copyMem((void*)this->imageFilepath, (void*)str, sizeof(char) * strLength);
+		g_memory_copyMem((void*)this->imageFilepath, sizeof(char) * (strLength + 1), (void*)str, sizeof(char) * strLength);
 		this->imageFilepath[strLength] = '\0';
 		this->imageFilepathLength = strLength;
 	}
@@ -1359,9 +1359,13 @@ namespace MathAnim
 			newNameLength = std::strlen(newName);
 		}
 
-		name = (uint8*)g_memory_realloc(name, sizeof(char) * (newNameLength + 1));
-		nameLength = (int32_t)newNameLength;
-		g_memory_copyMem(name, (void*)newName, newNameLength * sizeof(char));
+		if (newNameLength != nameLength)
+		{
+			name = (uint8*)g_memory_realloc(name, sizeof(char) * (newNameLength + 1));
+			nameLength = (int32_t)newNameLength;
+		}
+
+		g_memory_copyMem(name, sizeof(char) * (newNameLength + 1), (void*)newName, newNameLength * sizeof(char));
 		name[newNameLength] = '\0';
 	}
 
@@ -2341,7 +2345,7 @@ namespace MathAnim
 		const char* newObjName = "New Object";
 		res.nameLength = (uint32)std::strlen(newObjName);
 		res.name = (uint8*)g_memory_allocate(sizeof(uint8) * (res.nameLength + 1));
-		g_memory_copyMem(res.name, (void*)newObjName, sizeof(uint8) * (res.nameLength + 1));
+		g_memory_copyMem(res.name, sizeof(uint8) * (res.nameLength + 1), (void*)newObjName, sizeof(uint8) * (res.nameLength + 1));
 
 		res.status = AnimObjectStatus::Active;
 		res.objectType = type;

--- a/Animations/src/animation/AnimationManager.cpp
+++ b/Animations/src/animation/AnimationManager.cpp
@@ -557,7 +557,7 @@ namespace MathAnim
 				if (obj.status == AnimObjectStatus::Active)
 				{
 					const BBox& bbox = obj.bbox;
-					glm::mat4 transform = glm::translate(glm::identity<glm::mat4>(), glm::vec3(0, 0, obj.position.z));
+					glm::mat4 transform = glm::translate(glm::identity<glm::mat4>(), glm::vec3(0, 0, obj.globalPosition.z));
 					Renderer::pushColor(Colors::AccentGreen[2]);
 					Path2DContext* path = Renderer::beginPath(bbox.min, transform);
 					Renderer::lineTo(path, Vec2{ bbox.min.x, bbox.max.y });

--- a/Animations/src/animation/AnimationManager.cpp
+++ b/Animations/src/animation/AnimationManager.cpp
@@ -59,10 +59,7 @@ namespace MathAnim
 
 		AnimationManagerData* create()
 		{
-			void* animManagerMemory = g_memory_allocate(sizeof(AnimationManagerData));
-			// Placement new to ensure the vectors and stuff are appropriately constructed
-			// but I can still use my memory tracker
-			AnimationManagerData* res = new (animManagerMemory) AnimationManagerData();
+			AnimationManagerData* res = g_memory_new AnimationManagerData();
 
 			res->activeCamera = NULL_ANIM_OBJECT;
 			res->currentFrame = 0;
@@ -86,9 +83,7 @@ namespace MathAnim
 					am->animations[i].free();
 				}
 
-				// Call destructor to properly destruct vector objects
-				am->~AnimationManagerData();
-				g_memory_free(am);
+				g_memory_delete(am);
 			}
 		}
 

--- a/Animations/src/animation/SvgFileObject.cpp
+++ b/Animations/src/animation/SvgFileObject.cpp
@@ -53,7 +53,7 @@ namespace MathAnim
 			const char childName[] = "Generated Child";
 			childObj.nameLength = sizeof(childName);
 			childObj.name = (uint8*)g_memory_realloc(childObj.name, sizeof(uint8) * (childObj.nameLength + 1));
-			g_memory_copyMem(childObj.name, (void*)childName, sizeof(childName) / sizeof(char));
+			g_memory_copyMem(childObj.name, sizeof(uint8) * (childObj.nameLength + 1), (void*)childName, sizeof(childName) / sizeof(char));
 			childObj.name[childObj.nameLength] = '\0';
 
 			AnimationManager::addAnimObject(am, childObj);
@@ -89,7 +89,7 @@ namespace MathAnim
 		filepath = (char*)g_memory_allocate(sizeof(char) * (newFilepath.length() + 1));
 		filepathLength = (uint32)newFilepath.length();
 
-		g_memory_copyMem(filepath, (void*)newFilepath.c_str(), sizeof(char) * newFilepath.length());
+		g_memory_copyMem(filepath, sizeof(char) * (newFilepath.length() + 1), (void*)newFilepath.c_str(), sizeof(char) * newFilepath.length());
 		filepath[filepathLength] = '\0';
 
 		// Try to parse the new SVG and reset to the old one if it fails

--- a/Animations/src/animation/TextAnimations.cpp
+++ b/Animations/src/animation/TextAnimations.cpp
@@ -46,13 +46,42 @@ namespace MathAnim
 
 		std::string textStr = std::string(text);
 
-		// Generate children that represent each character of the text object `obj`
-		Vec2 cursorPos = Vec2{ 0, 0 };
+		// First figure out the total size of the text so we can center it around the origin
+		Vec2 size = Vec2{ 0.0f, 0.0f };
 		for (int i = 0; i < textStr.length(); i++)
 		{
 			if (textStr[i] == '\n')
 			{
-				cursorPos = Vec2{ 0.0f, cursorPos.y - font->lineHeight };
+				size.y += font->lineHeight;
+				continue;
+			}
+
+			uint8 codepoint = (uint8)textStr[i];
+			const GlyphOutline& glyphOutline = font->getGlyphInfo(codepoint);
+			if (!glyphOutline.svg)
+			{
+				continue;
+			}
+
+			float halfGlyphHeight = glyphOutline.glyphHeight / 2.0f;
+			float halfGlyphWidth = glyphOutline.glyphWidth / 2.0f;
+			Vec2 offset = Vec2{
+				glyphOutline.bearingX + halfGlyphWidth,
+				halfGlyphHeight - glyphOutline.descentY
+			};
+
+			// TODO: I may have to add kerning info here
+			size.x += glyphOutline.advanceX;
+		}
+
+		// Generate children that represent each character of the text object `obj`
+		Vec2 halfSize = size / 2.0f;
+		Vec2 cursorPos = Vec2{ -halfSize.x, halfSize.y };
+		for (int i = 0; i < textStr.length(); i++)
+		{
+			if (textStr[i] == '\n')
+			{
+				cursorPos = Vec2{ -halfSize.x, cursorPos.y - font->lineHeight };
 				continue;
 			}
 

--- a/Animations/src/animation/TextAnimations.cpp
+++ b/Animations/src/animation/TextAnimations.cpp
@@ -22,7 +22,7 @@ namespace MathAnim
 	{
 		*ogText = (char*)g_memory_realloc(*ogText, sizeof(char) * (newTextLength + 1));
 		*ogTextLength = (int32_t)newTextLength;
-		g_memory_copyMem(*ogText, (void*)newText, newTextLength * sizeof(char));
+		g_memory_copyMem(*ogText, sizeof(char) * (newTextLength + 1), (void*)newText, newTextLength * sizeof(char));
 		(*ogText)[newTextLength] = '\0';
 	}
 
@@ -273,7 +273,7 @@ namespace MathAnim
 		res.font = nullptr;
 		static const char defaultText[] = "Text Object";
 		res.text = (char*)g_memory_allocate(sizeof(defaultText) / sizeof(char));
-		g_memory_copyMem(res.text, (void*)defaultText, sizeof(defaultText) / sizeof(char));
+		g_memory_copyMem(res.text, sizeof(defaultText) / sizeof(char), (void*)defaultText, sizeof(defaultText) / sizeof(char));
 		res.textLength = (sizeof(defaultText) / sizeof(char)) - 1;
 		res.text[res.textLength] = '\0';
 		return res;
@@ -431,7 +431,7 @@ namespace MathAnim
 		// Alternating harmonic series
 		static const char defaultLatex[] = R"raw(\sum _{k=1}^{\infty }{\frac {(-1)^{k+1}}{k}}={\frac {1}{1}}-{\frac {1}{2}}+{\frac {1}{3}}-{\frac {1}{4}}+\cdots =\ln 2)raw";
 		res.text = (char*)g_memory_allocate(sizeof(defaultLatex) / sizeof(char));
-		g_memory_copyMem(res.text, (void*)defaultLatex, sizeof(defaultLatex) / sizeof(char));
+		g_memory_copyMem(res.text, sizeof(defaultLatex) / sizeof(char), (void*)defaultLatex, sizeof(defaultLatex) / sizeof(char));
 		res.textLength = (sizeof(defaultLatex) / sizeof(char)) - 1;
 		res.text[res.textLength] = '\0';
 		res.isEquation = true;
@@ -674,7 +674,7 @@ int main()
 }
 )DEFAULT_LANG";
 		res.text = (char*)g_memory_allocate(sizeof(defaultText) / sizeof(char));
-		g_memory_copyMem(res.text, (void*)defaultText, sizeof(defaultText) / sizeof(char));
+		g_memory_copyMem(res.text, sizeof(defaultText) / sizeof(char), (void*)defaultText, sizeof(defaultText) / sizeof(char));
 		res.textLength = (sizeof(defaultText) / sizeof(char)) - 1;
 		res.text[res.textLength] = '\0';
 		return res;

--- a/Animations/src/core.cpp
+++ b/Animations/src/core.cpp
@@ -181,7 +181,7 @@ void RawMemory::writeDangerous(const uint8* inData, size_t inDataSize)
 		this->size = newSize;
 	}
 
-	g_memory_copyMem(this->data + this->offset, (uint8*)(inData), inDataSize);
+	g_memory_copyMem(this->data + this->offset, this->size, (uint8*)(inData), inDataSize);
 	this->offset += inDataSize;
 }
 
@@ -195,7 +195,7 @@ bool RawMemory::readDangerous(uint8* inData, size_t inDataSize)
 		return false;
 	}
 
-	g_memory_copyMem((uint8*)inData, this->data + this->offset, inDataSize);
+	g_memory_copyMem((uint8*)inData, this->size, this->data + this->offset, inDataSize);
 	this->offset += inDataSize;
 	return true;
 }

--- a/Animations/src/core/Application.cpp
+++ b/Animations/src/core/Application.cpp
@@ -28,6 +28,7 @@
 #include "editor/timeline/Timeline.h"
 #include "editor/imgui/ImGuiLayer.h"
 #include "editor/panels/SceneManagementPanel.h"
+#include "editor/panels/SceneHierarchyPanel.h"
 #include "editor/panels/InspectorPanel.h"
 #include "editor/panels/MenuBar.h"
 #include "editor/panels/ExportPanel.h"
@@ -463,6 +464,7 @@ namespace MathAnim
 			AnimationManager::serialize(am, sceneJson["AnimationManager"]);
 			Timeline::serialize(EditorGui::getTimelineData(), sceneJson["TimelineData"]);
 			sceneJson["EditorCameras"] = serializeCameras();
+			SceneHierarchyPanel::serialize(sceneJson["SceneHierarchy"]);
 
 			try
 			{
@@ -622,6 +624,11 @@ namespace MathAnim
 				}
 
 				deserializeCameras(sceneJson["EditorCameras"], versionMajor);
+
+				if (sceneJson.contains("SceneHierarchy") && !sceneJson["SceneHierarchy"].is_null())
+				{
+					SceneHierarchyPanel::deserialize(sceneJson["SceneHierarchy"]);
+				}
 			}
 			catch (const std::exception& ex)
 			{

--- a/Animations/src/core/Input.cpp
+++ b/Animations/src/core/Input.cpp
@@ -77,14 +77,14 @@ namespace MathAnim
 		void endFrame()
 		{
 			// Copy the mouse button down states to mouse button down last frame
-			g_memory_copyMem(mouseButtonDownLastFrame, mouseButtonDown, sizeof(bool) * (uint8)MouseButton::Length);
+			g_memory_copyMem(mouseButtonDownLastFrame, sizeof(bool) * (uint8)MouseButton::Length, mouseButtonDown, sizeof(bool) * (uint8)MouseButton::Length);
 
 			// Copy key down states
-			g_memory_copyMem(keyDownLastFrame, keyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
-			g_memory_copyMem(shiftKeyDownLastFrame, shiftKeyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
-			g_memory_copyMem(superKeyDownLastFrame, superKeyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
-			g_memory_copyMem(ctrlKeyDownLastFrame, ctrlKeyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
-			g_memory_copyMem(altKeyDownLastFrame, altKeyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
+			g_memory_copyMem(keyDownLastFrame, sizeof(bool) * (GLFW_KEY_LAST + 1), keyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
+			g_memory_copyMem(shiftKeyDownLastFrame, sizeof(bool) * (GLFW_KEY_LAST + 1), shiftKeyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
+			g_memory_copyMem(superKeyDownLastFrame, sizeof(bool) * (GLFW_KEY_LAST + 1), superKeyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
+			g_memory_copyMem(ctrlKeyDownLastFrame, sizeof(bool) * (GLFW_KEY_LAST + 1), ctrlKeyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
+			g_memory_copyMem(altKeyDownLastFrame, sizeof(bool) * (GLFW_KEY_LAST + 1), altKeyDownData, sizeof(bool) * (GLFW_KEY_LAST + 1));
 
 			// Reset mouse states
 			deltaMouseX = 0;

--- a/Animations/src/editor/Clipboard.cpp
+++ b/Animations/src/editor/Clipboard.cpp
@@ -20,17 +20,14 @@ namespace MathAnim
 
 		ClipboardData* create()
 		{
-			ClipboardData* data = (ClipboardData*)g_memory_allocate(sizeof(ClipboardData));
-			new(data)ClipboardData();
+			auto* data = g_memory_new ClipboardData();
 			return data;
 		}
 
 		void free(ClipboardData* data)
 		{
 			freeContents(data);
-			data->~ClipboardData();
-			g_memory_zeroMem(data, sizeof(ClipboardData));
-			g_memory_free(data);
+			g_memory_delete(data);
 		}
 
 		ClipboardContents getType(const ClipboardData* data)

--- a/Animations/src/editor/EditorGui.cpp
+++ b/Animations/src/editor/EditorGui.cpp
@@ -139,7 +139,7 @@ namespace MathAnim
 			ImGui::PopStyleVar();
 
 			AnimObjectPanel::update();
-			DebugPanel::update();
+			DebugPanel::update(am);
 			ExportPanel::update(am);
 			SceneHierarchyPanel::update(am);
 			AssetManagerPanel::update();

--- a/Animations/src/editor/Gizmos.cpp
+++ b/Animations/src/editor/Gizmos.cpp
@@ -424,13 +424,17 @@ namespace MathAnim
 					const Camera& orthoCamera = AnimationManager::getActiveCamera(am);
 
 					Renderer::pushStrokeWidth(0.05f);
+					
 					Renderer::pushColor(Colors::Neutral[0]);
 					Vec4 leftRightBottomTop = orthoCamera.getLeftRightBottomTop();
 					Vec2 projectionSize = CMath::abs(Vec2{
 						leftRightBottomTop.values[1] - leftRightBottomTop.values[0],
 						leftRightBottomTop.values[3] - leftRightBottomTop.values[2]
-						});
-					Renderer::drawSquare(CMath::vector2From3(orthoCamera.position) - projectionSize / 2.0f, projectionSize);
+					});
+					Vec2 camera2DPos = CMath::vector2From3(orthoCamera.position) - projectionSize / 2.0f;
+					glm::mat4 transform = glm::identity<glm::mat4>();
+					transform = glm::translate(transform, CMath::convert(Vec3{camera2DPos.x, camera2DPos.y, orthoCamera.position.z}));
+					Renderer::drawSquare(Vec2{0, 0}, projectionSize, transform);
 					Renderer::popColor();
 					Renderer::popStrokeWidth();
 				}

--- a/Animations/src/editor/Gizmos.cpp
+++ b/Animations/src/editor/Gizmos.cpp
@@ -87,6 +87,7 @@ namespace MathAnim
 		Vec3 mouseDelta;
 		FollowMouseConstraint moveMode;
 		bool shouldDraw;
+		bool drawCubeVisualization;
 
 		void render();
 	};
@@ -424,17 +425,17 @@ namespace MathAnim
 					const Camera& orthoCamera = AnimationManager::getActiveCamera(am);
 
 					Renderer::pushStrokeWidth(0.05f);
-					
+
 					Renderer::pushColor(Colors::Neutral[0]);
 					Vec4 leftRightBottomTop = orthoCamera.getLeftRightBottomTop();
 					Vec2 projectionSize = CMath::abs(Vec2{
 						leftRightBottomTop.values[1] - leftRightBottomTop.values[0],
 						leftRightBottomTop.values[3] - leftRightBottomTop.values[2]
-					});
+						});
 					Vec2 camera2DPos = CMath::vector2From3(orthoCamera.position) - projectionSize / 2.0f;
 					glm::mat4 transform = glm::identity<glm::mat4>();
-					transform = glm::translate(transform, CMath::convert(Vec3{camera2DPos.x, camera2DPos.y, orthoCamera.position.z}));
-					Renderer::drawSquare(Vec2{0, 0}, projectionSize, transform);
+					transform = glm::translate(transform, CMath::convert(Vec3{ camera2DPos.x, camera2DPos.y, orthoCamera.position.z }));
+					Renderer::drawSquare(Vec2{ 0, 0 }, projectionSize, transform);
 					Renderer::popColor();
 					Renderer::popStrokeWidth();
 				}
@@ -604,7 +605,7 @@ namespace MathAnim
 			return gGizmoManager->visualMode;
 		}
 
-		ImGuiDataEx<Vec3> translateGizmo(const char* gizmoName, Vec3* position)
+		ImGuiDataEx<Vec3> translateGizmo(const char* gizmoName, Vec3* position, bool drawCubeVisualization)
 		{
 			// Find or create the gizmo
 			GizmoState* gizmo = getGizmoByName(gizmoName, GizmoType::Translation);
@@ -615,6 +616,7 @@ namespace MathAnim
 				gizmo->positionMoveStart = *position;
 			}
 			gizmo->position = *position;
+			gizmo->drawCubeVisualization = drawCubeVisualization;
 
 			Vec3 delta = Vec3{ 0.f, 0.f, 0.f };
 			if (handleLinearGizmoKeyEvents(gizmo, *position, &delta, GLFW_KEY_G, GizmoType::Translation))
@@ -625,7 +627,7 @@ namespace MathAnim
 				bool finishedEditing = gGizmoManager->activeGizmo != gizmo->idHash && gizmo->positionMoveStart != *position;
 				return {
 					gizmo->positionMoveStart,
-					finishedEditing 
+					finishedEditing
 					? EditState::FinishedEditing
 					: EditState::BeingEdited
 				};
@@ -1346,6 +1348,7 @@ namespace MathAnim
 			gizmoState->shouldDraw = false;
 			gizmoState->moveMode = FollowMouseConstraint::None;
 			gizmoState->mouseDelta = Vec3{ 0.0f, 0.0f, 0.0f };
+			gizmoState->drawCubeVisualization = false;
 
 			GlobalContext* g = gGizmoManager;
 			g->gizmos.push_back(gizmoState);
@@ -1557,6 +1560,11 @@ namespace MathAnim
 			leftRightBottomTop.values[1] - leftRightBottomTop.values[0],
 			leftRightBottomTop.values[3] - leftRightBottomTop.values[2]
 		};
+
+		if (drawCubeVisualization)
+		{
+			Renderer::drawCube3D(this->position, Vec3{0.1f, 0.1f, 0.1f} *zoom, Vector3::Forward, Vector3::Up);
+		}
 
 		// If it's in free move mode, render guidelines
 		if (moveMode != FollowMouseConstraint::None || idHash == g->activeGizmo)

--- a/Animations/src/editor/Gizmos.cpp
+++ b/Animations/src/editor/Gizmos.cpp
@@ -352,8 +352,7 @@ namespace MathAnim
 
 		void init()
 		{
-			void* gMemory = g_memory_allocate(sizeof(GlobalContext));
-			gGizmoManager = new(gMemory)GlobalContext();
+			gGizmoManager = g_memory_new GlobalContext();
 			gGizmoManager->hoveredGizmo = NullGizmo;
 			gGizmoManager->activeGizmo = NullGizmo;
 			gGizmoManager->mouseWorldPos3f = Vec3{ 0.0f, 0.0f, 0.0f };
@@ -554,8 +553,7 @@ namespace MathAnim
 					iter = gGizmoManager->gizmos.erase(iter);
 				}
 
-				gGizmoManager->~GlobalContext();
-				g_memory_free(gGizmoManager);
+				g_memory_delete(gGizmoManager);
 				gGizmoManager = nullptr;
 			}
 

--- a/Animations/src/editor/UndoSystem.cpp
+++ b/Animations/src/editor/UndoSystem.cpp
@@ -2055,7 +2055,7 @@ namespace MathAnim
 						break;
 					case U8Vec4PropType::StrokeColor:
 						this->oldProps[childId] = childObj->_strokeColorStart;
-						childObj->_fillColorStart = obj->_strokeColorStart;
+						childObj->_strokeColorStart = obj->_strokeColorStart;
 						break;
 					}
 				}

--- a/Animations/src/editor/UndoSystem.cpp
+++ b/Animations/src/editor/UndoSystem.cpp
@@ -480,8 +480,7 @@ namespace MathAnim
 				// Don't free the tail, nothing ever gets placed there
 				if (i == ((us->undoCursorHead + us->numCommands) % us->maxHistorySize)) break;
 
-				us->history[i]->~Command();
-				g_memory_free(us->history[i]);
+				g_memory_delete(us->history[i]);
 			}
 
 			g_memory_free(us->history);
@@ -523,15 +522,13 @@ namespace MathAnim
 
 		void setBoolProp(UndoSystemData* us, ObjOrAnimId id, bool oldBool, bool newBool, BoolPropType propType)
 		{
-			auto* newCommand = (ModifyBoolCommand*)g_memory_allocate(sizeof(ModifyBoolCommand));
-			new(newCommand)ModifyBoolCommand(id, oldBool, newBool, propType);
+			auto* newCommand = g_memory_new ModifyBoolCommand(id, oldBool, newBool, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
 		void applyU8Vec4ToChildren(UndoSystemData* us, ObjOrAnimId id, U8Vec4PropType propType)
 		{
-			auto* newCommand = (ApplyU8Vec4ToChildrenCommand*)g_memory_allocate(sizeof(ApplyU8Vec4ToChildrenCommand));
-			new(newCommand)ApplyU8Vec4ToChildrenCommand(id, propType);
+			auto* newCommand = g_memory_new ApplyU8Vec4ToChildrenCommand(id, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -543,8 +540,7 @@ namespace MathAnim
 				return;
 			}
 
-			auto* newCommand = (ModifyU8Vec4Command*)g_memory_allocate(sizeof(ModifyU8Vec4Command));
-			new(newCommand)ModifyU8Vec4Command(objId, oldVec, newVec, propType);
+			auto* newCommand = g_memory_new ModifyU8Vec4Command(objId, oldVec, newVec, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -600,8 +596,7 @@ namespace MathAnim
 				break;
 			}
 
-			auto* newCommand = (ModifyEnumCommand*)g_memory_allocate(sizeof(ModifyEnumCommand));
-			new(newCommand)ModifyEnumCommand(id, oldEnum, newEnum, propType);
+			auto* newCommand = g_memory_new ModifyEnumCommand(id, oldEnum, newEnum, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -613,8 +608,7 @@ namespace MathAnim
 				return;
 			}
 
-			auto* newCommand = (ModifyFloatCommand*)g_memory_allocate(sizeof(ModifyFloatCommand));
-			new(newCommand)ModifyFloatCommand(objId, oldValue, newValue, propType);
+			auto* newCommand = g_memory_new ModifyFloatCommand(objId, oldValue, newValue, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -626,8 +620,7 @@ namespace MathAnim
 				return;
 			}
 
-			auto* newCommand = (ModifyVec2Command*)g_memory_allocate(sizeof(ModifyVec2Command));
-			new(newCommand)ModifyVec2Command(objId, oldVec, newVec, propType);
+			auto* newCommand = g_memory_new ModifyVec2Command(objId, oldVec, newVec, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -639,8 +632,7 @@ namespace MathAnim
 				return;
 			}
 
-			auto* newCommand = (ModifyVec2iCommand*)g_memory_allocate(sizeof(ModifyVec2iCommand));
-			new(newCommand)ModifyVec2iCommand(objId, oldVec, newVec, propType);
+			auto* newCommand = g_memory_new ModifyVec2iCommand(objId, oldVec, newVec, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -652,8 +644,7 @@ namespace MathAnim
 				return;
 			}
 
-			auto* newCommand = (ModifyVec3Command*)g_memory_allocate(sizeof(ModifyVec3Command));
-			new(newCommand)ModifyVec3Command(objId, oldVec, newVec, propType);
+			auto* newCommand = g_memory_new ModifyVec3Command(objId, oldVec, newVec, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -665,8 +656,7 @@ namespace MathAnim
 				return;
 			}
 
-			auto* newCommand = (ModifyVec4Command*)g_memory_allocate(sizeof(ModifyVec4Command));
-			new(newCommand)ModifyVec4Command(objId, oldVec, newVec, propType);
+			auto* newCommand = g_memory_new ModifyVec4Command(objId, oldVec, newVec, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -678,8 +668,7 @@ namespace MathAnim
 				return;
 			}
 
-			auto* newCommand = (ModifyStringCommand*)g_memory_allocate(sizeof(ModifyStringCommand));
-			new(newCommand)ModifyStringCommand(objId, oldString, newString, propType);
+			auto* newCommand = g_memory_new ModifyStringCommand(objId, oldString, newString, propType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -691,29 +680,25 @@ namespace MathAnim
 				return;
 			}
 
-			auto* newCommand = (SetFontCommand*)g_memory_allocate(sizeof(SetFontCommand));
-			new(newCommand)SetFontCommand(objId, oldFont, newFont);
+			auto* newCommand = g_memory_new SetFontCommand(objId, oldFont, newFont);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
 		void animDragDropInput(UndoSystemData* us, AnimObjId oldTarget, AnimObjId newTarget, AnimId animToAddTo, AnimDragDropType type)
 		{
-			auto* newCommand = (AnimDragDropInputCommand*)g_memory_allocate(sizeof(AnimDragDropInputCommand));
-			new(newCommand)AnimDragDropInputCommand(oldTarget, newTarget, animToAddTo, type);
+			auto* newCommand = g_memory_new AnimDragDropInputCommand(oldTarget, newTarget, animToAddTo, type);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
 		void addObjectToAnim(UndoSystemData* us, AnimObjId objToAdd, AnimId animToAddTo)
 		{
-			auto* newCommand = (AddObjectToAnimCommand*)g_memory_allocate(sizeof(AddObjectToAnimCommand));
-			new(newCommand)AddObjectToAnimCommand(objToAdd, animToAddTo);
+			auto* newCommand = g_memory_new AddObjectToAnimCommand(objToAdd, animToAddTo);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
 		void removeObjectFromAnim(UndoSystemData* us, AnimObjId objToAdd, AnimId animToAddTo)
 		{
-			auto* newCommand = (RemoveObjectFromAnimCommand*)g_memory_allocate(sizeof(RemoveObjectFromAnimCommand));
-			new(newCommand)RemoveObjectFromAnimCommand(objToAdd, animToAddTo);
+			auto* newCommand = g_memory_new RemoveObjectFromAnimCommand(objToAdd, animToAddTo);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -722,15 +707,13 @@ namespace MathAnim
 			assertEnumInRange<AnimObjectTypeV1>(animObjType);
 			g_logger_assert((AnimObjectTypeV1)animObjType != AnimObjectTypeV1::None, "Cannot create AnimObject of type 'None'");
 
-			auto* newCommand = (AddObjectToSceneCommand*)g_memory_allocate(sizeof(AddObjectToSceneCommand));
-			new(newCommand)AddObjectToSceneCommand((AnimObjectTypeV1)animObjType);
+			auto* newCommand = g_memory_new AddObjectToSceneCommand((AnimObjectTypeV1)animObjType);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
 		void removeObjFromScene(UndoSystemData* us, AnimObjId objId)
 		{
-			auto* newCommand = (RemoveObjectFromSceneCommand*)g_memory_allocate(sizeof(RemoveObjectFromSceneCommand));
-			new(newCommand)RemoveObjectFromSceneCommand(objId);
+			auto* newCommand = g_memory_new RemoveObjectFromSceneCommand(objId);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -741,8 +724,7 @@ namespace MathAnim
 			{
 				if (oldFrameStart != newFrameStart || newFrameDuration != oldFrameDuration)
 				{
-					auto* newCommand = (SetAnimationTimeCommand*)g_memory_allocate(sizeof(SetAnimationTimeCommand));
-					new(newCommand)SetAnimationTimeCommand(id, oldFrameStart, oldFrameDuration, newFrameStart, newFrameDuration);
+					auto* newCommand = g_memory_new SetAnimationTimeCommand(id, oldFrameStart, oldFrameDuration, newFrameStart, newFrameDuration);
 					pushAndExecuteCommand(us, newCommand);
 				}
 			}
@@ -753,15 +735,13 @@ namespace MathAnim
 			assertEnumInRange<AnimTypeV1>(animType);
 			g_logger_assert((AnimTypeV1)animType != AnimTypeV1::None, "Cannot create Animation of type 'None'");
 
-			auto* newCommand = (AddAnimationToTimelineCommand*)g_memory_allocate(sizeof(AddAnimationToTimelineCommand));
-			new(newCommand)AddAnimationToTimelineCommand((AnimTypeV1)animType, frameStart, frameDuration, trackIndex);
+			auto* newCommand = g_memory_new AddAnimationToTimelineCommand((AnimTypeV1)animType, frameStart, frameDuration, trackIndex);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
 		void removeAnimationFromTimeline(UndoSystemData* us, AnimId animId)
 		{
-			auto* newCommand = (RemoveAnimationFromTimelineCommand*)g_memory_allocate(sizeof(RemoveAnimationFromTimelineCommand));
-			new(newCommand)RemoveAnimationFromTimelineCommand(animId);
+			auto* newCommand = g_memory_new RemoveAnimationFromTimelineCommand(animId);
 			pushAndExecuteCommand(us, newCommand);
 		}
 
@@ -779,8 +759,7 @@ namespace MathAnim
 				{
 					if (i == ((us->undoCursorHead + us->numCommands) % us->maxHistorySize)) break;
 
-					us->history[i]->~Command();
-					g_memory_free(us->history[i]);
+					g_memory_delete(us->history[i]);
 					numCommandsRemoved++;
 				}
 
@@ -790,8 +769,7 @@ namespace MathAnim
 
 			if (((us->undoCursorTail + 1) % us->maxHistorySize) == us->undoCursorHead)
 			{
-				us->history[us->undoCursorHead]->~Command();
-				g_memory_free(us->history[us->undoCursorHead]);
+				g_memory_delete(us->history[us->undoCursorHead]);
 
 				us->undoCursorHead = (us->undoCursorHead + 1) % us->maxHistorySize;
 				us->numCommands--;

--- a/Animations/src/editor/UndoSystem.cpp
+++ b/Animations/src/editor/UndoSystem.cpp
@@ -1530,10 +1530,6 @@ namespace MathAnim
 		{
 			switch (propType)
 			{
-			case Vec2PropType::MoveToTargetPos:
-				assertCorrectType(anim, AnimTypeV1::MoveTo);
-				anim->as.moveTo.target = this->newVec;
-				break;
 			case Vec2PropType::AnimateScaleTarget:
 				assertCorrectType(anim, AnimTypeV1::AnimateScale);
 				anim->as.animateScale.target = this->newVec;
@@ -1549,10 +1545,6 @@ namespace MathAnim
 		{
 			switch (propType)
 			{
-			case Vec2PropType::MoveToTargetPos:
-				assertCorrectType(anim, AnimTypeV1::MoveTo);
-				anim->as.moveTo.target = this->oldVec;
-				break;
 			case Vec2PropType::AnimateScaleTarget:
 				assertCorrectType(anim, AnimTypeV1::AnimateScale);
 				anim->as.animateScale.target = this->oldVec;
@@ -1645,6 +1637,7 @@ namespace MathAnim
 				break;
 				// NOTE: These are animations
 			case Vec3PropType::ModifyAnimationVec3Target:
+			case Vec3PropType::MoveToTargetPos:
 				break;
 			}
 			AnimationManager::updateObjectState(am, this->objId);
@@ -1658,6 +1651,10 @@ namespace MathAnim
 			case Vec3PropType::ModifyAnimationVec3Target:
 				assertAnimIsModifyVec3Type(anim);
 				anim->as.modifyVec3.target = this->newVec;
+				break;
+			case Vec3PropType::MoveToTargetPos:
+				assertCorrectType(anim, AnimTypeV1::MoveTo);
+				anim->as.moveTo.target = this->newVec;
 				break;
 				// NOTE: These are anim objects
 			case Vec3PropType::Position:
@@ -1691,6 +1688,7 @@ namespace MathAnim
 				break;
 				// NOTE: These are animations
 			case Vec3PropType::ModifyAnimationVec3Target:
+			case Vec3PropType::MoveToTargetPos:
 				break;
 			}
 			AnimationManager::updateObjectState(am, this->objId);
@@ -1704,6 +1702,10 @@ namespace MathAnim
 			case Vec3PropType::ModifyAnimationVec3Target:
 				assertAnimIsModifyVec3Type(anim);
 				anim->as.modifyVec3.target = this->oldVec;
+				break;
+			case Vec3PropType::MoveToTargetPos:
+				assertCorrectType(anim, AnimTypeV1::MoveTo);
+				anim->as.moveTo.target = this->oldVec;
 				break;
 				// NOTE: These are anim objects
 			case Vec3PropType::Position:

--- a/Animations/src/editor/UndoSystem.cpp
+++ b/Animations/src/editor/UndoSystem.cpp
@@ -1148,10 +1148,12 @@ namespace MathAnim
 			case EnumPropType::ImageRepeat:
 				assertCorrectType(obj, AnimObjectTypeV1::Image);
 				obj->as.image.repeatMode = (ImageRepeatMode)newEnum;
+				obj->as.image.reInit(am, obj, true);
 				break;
 			case EnumPropType::ImageSampleMode:
 				assertCorrectType(obj, AnimObjectTypeV1::Image);
 				obj->as.image.filterMode = (ImageFilterMode)newEnum;
+				obj->as.image.reInit(am, obj, true);
 				break;
 				// NOTE: These are animation types, so they go in the if-block above
 			case EnumPropType::EaseType:
@@ -1222,10 +1224,12 @@ namespace MathAnim
 			case EnumPropType::ImageRepeat:
 				assertCorrectType(obj, AnimObjectTypeV1::Image);
 				obj->as.image.repeatMode = (ImageRepeatMode)oldEnum;
+				obj->as.image.reInit(am, obj, true);
 				break;
 			case EnumPropType::ImageSampleMode:
 				assertCorrectType(obj, AnimObjectTypeV1::Image);
 				obj->as.image.filterMode = (ImageFilterMode)oldEnum;
+				obj->as.image.reInit(am, obj, true);
 				break;
 				// NOTE: These are animation types, so they go in the if-block above
 			case EnumPropType::EaseType:

--- a/Animations/src/editor/imgui/ImGuiExtended.cpp
+++ b/Animations/src/editor/imgui/ImGuiExtended.cpp
@@ -402,12 +402,12 @@ namespace MathAnim
 			{
 				if (outBufferSize >= (objPayload->filepathLength + 1))
 				{
-					g_memory_copyMem((void*)outBuffer, (void*)objPayload->filepath, sizeof(char) * objPayload->filepathLength);
+					g_memory_copyMem((void*)outBuffer, outBufferSize,(void*)objPayload->filepath, sizeof(char) * objPayload->filepathLength);
 					outBuffer[objPayload->filepathLength] = '\0';
 				}
 				else
 				{
-					g_memory_copyMem((void*)outBuffer, (void*)objPayload->filepath, sizeof(char) * outBufferSize);
+					g_memory_copyMem((void*)outBuffer, outBufferSize,(void*)objPayload->filepath, sizeof(char) * outBufferSize);
 					outBuffer[outBufferSize - 1] = '\0';
 					g_logger_warning("File drag drop target got filepath of length '{}' that was too long to fit into buffer of length '{}'. Truncating filename.", objPayload->filepathLength, outBufferSize);
 				}

--- a/Animations/src/editor/panels/AssetManagerPanel.cpp
+++ b/Animations/src/editor/panels/AssetManagerPanel.cpp
@@ -40,8 +40,7 @@ namespace MathAnim
 			scriptsRoot = assetsRoot/"scripts";
 
 			// Initialize the script watcher
-			scriptWatcher = (FileSystemWatcher*)g_memory_allocate(sizeof(FileSystemWatcher));
-			new(scriptWatcher)FileSystemWatcher();
+			scriptWatcher = g_memory_new FileSystemWatcher();
 			scriptWatcher->path = scriptsRoot;
 			scriptWatcher->onChanged = onScriptChanged;
 			scriptWatcher->onRenamed = onScriptRenamed;
@@ -75,8 +74,7 @@ namespace MathAnim
 		{
 			if (scriptWatcher)
 			{
-				scriptWatcher->~FileSystemWatcher();
-				g_memory_free(scriptWatcher);
+				g_memory_delete(scriptWatcher);
 			}
 
 			scriptWatcher = nullptr;
@@ -108,7 +106,7 @@ namespace MathAnim
 				{
 					filename = filename.substr(0, stringBufferSize - 1);
 				}
-				g_memory_copyMem(stringBuffer, (void*)filename.c_str(), filename.length());
+				g_memory_copyMem(stringBuffer, stringBufferSize,(void*)filename.c_str(), filename.length());
 				stringBuffer[filename.length()] = '\0';
 
 				if (ImGuiExtended::RenamableIconSelectable(icon, stringBuffer, stringBufferSize, lastSelectedFile == fileIndex, 132.0f))
@@ -150,7 +148,7 @@ namespace MathAnim
 					{
 						payload.filepathLength = filepath.length();
 						payload.filepath = buffer;
-						g_memory_copyMem((void*)buffer, (void*)filepath.c_str(), sizeof(char) * filepath.length());
+						g_memory_copyMem((void*)buffer, bufferSize, (void*)filepath.c_str(), sizeof(char) * filepath.length());
 						buffer[payload.filepathLength] = '\0';
 						ImGui::Text("%s", buffer);
 					}

--- a/Animations/src/editor/panels/DebugPanel.cpp
+++ b/Animations/src/editor/panels/DebugPanel.cpp
@@ -6,6 +6,7 @@
 #include "renderer/Colors.h"
 #include "renderer/Texture.h"
 #include "renderer/Renderer.h"
+#include "animation/AnimationManager.h"
 
 namespace MathAnim
 {
@@ -21,7 +22,7 @@ namespace MathAnim
 
 		}
 
-		void update()
+		void update(AnimationManagerData* am)
 		{
 			ImGui::Begin("Debug");
 
@@ -189,6 +190,12 @@ namespace MathAnim
 				}
 
 				ImGui::TreePop();
+			}
+
+			{
+				static bool drawAllBoundingBoxes = false;
+				ImGui::Checkbox(": Draw All Bounding Boxes", &drawAllBoundingBoxes);
+				AnimationManager::setRenderAllBoundingBoxes(am, drawAllBoundingBoxes);
 			}
 
 			ImGui::End();

--- a/Animations/src/editor/panels/ErrorPopups.cpp
+++ b/Animations/src/editor/panels/ErrorPopups.cpp
@@ -14,14 +14,21 @@ namespace MathAnim
 		static std::string missingFilename = "";
 		static std::string missingFilenameAdditionalMsg = "";
 
+		static bool textureLoadErrorPopupOpen = false;
+		static const char* ERROR_LOADING_TEXTURE_POPUP = "Error Loading Texture##ERROR_LOADING_TEXTURE";
+		static std::string textureLoadError = "";
+		static std::string textureLoadName = "";
+
 		// ------- Internal Funcs -------
 		static void handleSvgErrorPopup();
 		static void handleMissingFilePopup();
+		static void handleTextureLoadErrorPopup();
 
 		void update(AnimationManagerData*)
 		{
 			handleSvgErrorPopup();
 			handleMissingFilePopup();
+			handleTextureLoadErrorPopup();
 		}
 
 		void popupSvgImportError()
@@ -86,6 +93,47 @@ namespace MathAnim
 				ImGui::TextColored(Colors::AccentRed[3], "Error: ");
 				ImGui::SameLine();
 				ImGui::Text("File '%s' does not exist.", missingFilename.c_str());
+				ImGui::NewLine();
+				ImGui::Separator();
+
+				if (ImGui::Button("OK", ImVec2(120, 0)))
+				{
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SetItemDefaultFocus();
+				ImGui::EndPopup();
+			}
+		}
+
+		void popupTextureLoadError(const std::string& textureName, const std::string& errorMessage)
+		{
+			if (!textureLoadErrorPopupOpen)
+			{
+				textureLoadErrorPopupOpen = true;
+				textureLoadError = errorMessage;
+				textureLoadName = textureName;
+			}
+		}
+
+		static void handleTextureLoadErrorPopup()
+		{
+			if (textureLoadErrorPopupOpen)
+			{
+				ImGui::OpenPopup(ERROR_LOADING_TEXTURE_POPUP);
+				textureLoadErrorPopupOpen = false;
+			}
+
+			// Always center this window when appearing
+			ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+			ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+
+			if (ImGui::BeginPopupModal(ERROR_LOADING_TEXTURE_POPUP, NULL, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				ImGui::Text("Failed to load texture '%s'.", textureLoadName.c_str());
+				ImGui::TextColored(Colors::AccentRed[3], "Error: ");
+				ImGui::SameLine();
+				ImGui::Text("'%s'", textureLoadError.c_str());
+
 				ImGui::NewLine();
 				ImGui::Separator();
 

--- a/Animations/src/editor/panels/ExportPanel.cpp
+++ b/Animations/src/editor/panels/ExportPanel.cpp
@@ -130,7 +130,7 @@ namespace MathAnim
 					size_t pathLength = std::strlen(outPath);
 					if (pathLength < filenameBufferSize)
 					{
-						g_memory_copyMem(filenameBuffer, outPath, pathLength);
+						g_memory_copyMem(filenameBuffer, filenameBufferSize, outPath, pathLength);
 						filenameBuffer[pathLength] = '\0';
 					}
 

--- a/Animations/src/editor/panels/InspectorPanel.cpp
+++ b/Animations/src/editor/panels/InspectorPanel.cpp
@@ -180,7 +180,7 @@ namespace MathAnim
 				char scratch[scratchLength] = {};
 				if (animObject->nameLength < scratchLength - 1)
 				{
-					g_memory_copyMem(scratch, animObject->name, animObject->nameLength * sizeof(char));
+					g_memory_copyMem(scratch, scratchLength, animObject->name, animObject->nameLength * sizeof(char));
 					scratch[animObject->nameLength] = '\0';
 					if (auto res = ImGuiExtended::InputTextEx(": Name", scratch, scratchLength * sizeof(char));
 						res.editState != EditState::NotEditing)
@@ -644,7 +644,7 @@ namespace MathAnim
 				g_logger_error("Text object has more than 256 characters. Tell Gabe to increase scratch length for text objects.");
 				return;
 			}
-			g_memory_copyMem(scratch, object->as.textObject.text, object->as.textObject.textLength * sizeof(char));
+			g_memory_copyMem(scratch, scratchLength, object->as.textObject.text, object->as.textObject.textLength * sizeof(char));
 			scratch[object->as.textObject.textLength] = '\0';
 			if (auto res = ImGuiExtended::InputTextMultilineEx(": Text##TextObject", scratch, scratchLength * sizeof(char));
 				res.editState != EditState::NotEditing)
@@ -752,7 +752,7 @@ namespace MathAnim
 				codeEditUserData.tokenMatch = {};
 			}
 
-			g_memory_copyMem(scratch, object->as.codeBlock.text, object->as.codeBlock.textLength * sizeof(char));
+			g_memory_copyMem(scratch, scratchLength, object->as.codeBlock.text, object->as.codeBlock.textLength * sizeof(char));
 			scratch[object->as.codeBlock.textLength] = '\0';
 			if (auto res = ImGuiExtended::InputTextMultilineEx(": Code##CodeBlockData", scratch, scratchLength * sizeof(char), ImVec2(0, 0), ImGuiInputTextFlags_CallbackAlways, codeEditCallback, &codeEditUserData);
 				res.editState != EditState::NotEditing)
@@ -846,7 +846,7 @@ namespace MathAnim
 				g_logger_error("Text object has more than '{}' characters. Tell Gabe to increase scratch length for LaTex objects.", scratchLength);
 				return;
 			}
-			g_memory_copyMem(scratch, object->as.laTexObject.text, object->as.laTexObject.textLength * sizeof(char));
+			g_memory_copyMem(scratch, scratchLength, object->as.laTexObject.text, object->as.laTexObject.textLength * sizeof(char));
 			scratch[object->as.laTexObject.textLength] = '\0';
 			if (auto res = ImGuiExtended::InputTextMultilineEx(": LaTeX##LaTeXEditor", scratch, scratchLength * sizeof(char));
 				res.editState != EditState::NotEditing)
@@ -1643,7 +1643,7 @@ namespace MathAnim
 			char buffer[bufferSize] = "Drag File Here";
 			if (bufferSize >= script.scriptFilepathLength + 1 && script.scriptFilepathLength > 0)
 			{
-				g_memory_copyMem((void*)buffer, script.scriptFilepath, sizeof(char) * script.scriptFilepathLength);
+				g_memory_copyMem((void*)buffer, bufferSize, script.scriptFilepath, sizeof(char) * script.scriptFilepathLength);
 				buffer[script.scriptFilepathLength] = '\0';
 			}
 

--- a/Animations/src/editor/panels/InspectorPanel.cpp
+++ b/Animations/src/editor/panels/InspectorPanel.cpp
@@ -1063,15 +1063,15 @@ namespace MathAnim
 				);
 			}
 
-			if (auto res = ImGuiExtended::DragFloat2Ex(": Target Position##MoveToAnimation", &animation->as.moveTo.target, slowDragSpeed);
+			if (auto res = ImGuiExtended::DragFloat3Ex(": Target Position##MoveToAnimation", &animation->as.moveTo.target, slowDragSpeed);
 				res.editState == EditState::FinishedEditing)
 			{
-				UndoSystem::setVec2Prop(
+				UndoSystem::setVec3Prop(
 					Application::getUndoSystem(),
 					animation->id,
 					res.ogData,
 					animation->as.moveTo.target,
-					Vec2PropType::MoveToTargetPos
+					Vec3PropType::MoveToTargetPos
 				);
 			}
 		}

--- a/Animations/src/editor/panels/SceneManagementPanel.cpp
+++ b/Animations/src/editor/panels/SceneManagementPanel.cpp
@@ -39,7 +39,7 @@ namespace MathAnim
 				{
 					sd.sceneNames[i] = sd.sceneNames[i].substr(0, stringBufferSize - 1);
 				}
-				g_memory_copyMem(stringBuffer, (void*)sd.sceneNames[i].c_str(), sd.sceneNames[i].length());
+				g_memory_copyMem(stringBuffer, stringBufferSize,(void*)sd.sceneNames[i].c_str(), sd.sceneNames[i].length());
 				stringBuffer[sd.sceneNames[i].length()] = '\0';
 
 				if (i == sd.currentScene)

--- a/Animations/src/editor/timeline/Timeline.cpp
+++ b/Animations/src/editor/timeline/Timeline.cpp
@@ -161,8 +161,8 @@ namespace MathAnim
 
 						size_t pathLength = std::strlen(outPath);
 						timelineData.audioSourceFile = (uint8*)g_memory_realloc(timelineData.audioSourceFile, sizeof(uint8) * (pathLength + 1));
-						g_memory_copyMem(timelineData.audioSourceFile, outPath, sizeof(uint8) * (pathLength + 1));
 						timelineData.audioSourceFileLength = pathLength;
+						g_memory_copyMem(timelineData.audioSourceFile, sizeof(uint8) * (timelineData.audioSourceFileLength + 1), outPath, sizeof(uint8) * (pathLength + 1));
 
 						std::free(outPath);
 					}
@@ -457,7 +457,7 @@ namespace MathAnim
 			{
 				constexpr size_t defaultTrackNameLength = sizeof(defaultTrackName) / sizeof(defaultTrackName[0]);
 				char* trackName = (char*)g_memory_allocate(sizeof(char) * defaultTrackNameLength);
-				g_memory_copyMem(trackName, (void*)defaultTrackName, sizeof(char) * defaultTrackNameLength);
+				g_memory_copyMem(trackName, sizeof(char) * defaultTrackNameLength, (void*)defaultTrackName, sizeof(char) * defaultTrackNameLength);
 				trackName[defaultTrackNameLength - 3] = counterString[0];
 				trackName[defaultTrackNameLength - 2] = counterString[1];
 				defaultTrack.trackName = trackName;

--- a/Animations/src/latex/LaTexLayer.cpp
+++ b/Animations/src/latex/LaTexLayer.cpp
@@ -97,8 +97,8 @@ namespace MathAnim
 				size_t latexExeNameLength = std::strlen(latexExeName);
 				if (latexInstallLocationLength + latexExeNameLength + 1 <= MATH_ANIMATIONS_MAX_PATH)
 				{
-					g_memory_copyMem(latexProgram, latexInstallLocation, sizeof(char) * latexInstallLocationLength);
-					g_memory_copyMem(latexProgram + latexInstallLocationLength, (void*)latexExeName, sizeof(char) * latexExeNameLength);
+					g_memory_copyMem(latexProgram, MATH_ANIMATIONS_MAX_PATH, latexInstallLocation, sizeof(char) * latexInstallLocationLength);
+					g_memory_copyMem(latexProgram + latexInstallLocationLength, MATH_ANIMATIONS_MAX_PATH - latexInstallLocationLength, (void*)latexExeName, sizeof(char) * latexExeNameLength);
 					latexProgram[latexInstallLocationLength + latexExeNameLength] = '\0';
 
 					if (Platform::fileExists(latexProgram))
@@ -121,8 +121,8 @@ namespace MathAnim
 				size_t dvisvgmExeLength = std::strlen(dvisvgmExeName);
 				if (latexInstallLocationLength + dvisvgmExeLength + 1 <= MATH_ANIMATIONS_MAX_PATH)
 				{
-					g_memory_copyMem(dvisvgmProgram, latexInstallLocation, sizeof(char) * latexInstallLocationLength);
-					g_memory_copyMem(dvisvgmProgram + latexInstallLocationLength, (void*)dvisvgmExeName, sizeof(char) * dvisvgmExeLength);
+					g_memory_copyMem(dvisvgmProgram, MATH_ANIMATIONS_MAX_PATH, latexInstallLocation, sizeof(char) * latexInstallLocationLength);
+					g_memory_copyMem(dvisvgmProgram + latexInstallLocationLength, MATH_ANIMATIONS_MAX_PATH - latexInstallLocationLength, (void*)dvisvgmExeName, sizeof(char) * dvisvgmExeLength);
 					dvisvgmProgram[latexInstallLocationLength + dvisvgmExeLength] = '\0';
 
 					if (Platform::fileExists(dvisvgmProgram))
@@ -158,7 +158,7 @@ namespace MathAnim
 			{
 				LaTexTask* taskData = (LaTexTask*)g_memory_allocate(sizeof(LaTexTask));
 				taskData->laTex = (char*)g_memory_allocate(sizeof(char) * latex.length() + 1);
-				g_memory_copyMem(taskData->laTex, (void*)latex.c_str(), sizeof(char) * latex.length());
+				g_memory_copyMem(taskData->laTex, sizeof(char) * latex.length() + 1, (void*)latex.c_str(), sizeof(char) * latex.length());
 				taskData->laTex[latex.length()] = '\0';
 				taskData->isMathTex = isMathTex;
 

--- a/Animations/src/parsers/Common.cpp
+++ b/Animations/src/parsers/Common.cpp
@@ -406,7 +406,7 @@ namespace MathAnim
 				constexpr int maxSmallBufferSize = 32;
 				char smallBuffer[maxSmallBufferSize];
 				g_logger_assert(numberEnd - numberStart <= maxSmallBufferSize, "Cannot parse number greater than '{}' characters big.", maxSmallBufferSize);
-				g_memory_copyMem(smallBuffer, (void*)(parserInfo.text + numberStart), sizeof(char) * (numberEnd - numberStart));
+				g_memory_copyMem(smallBuffer, maxSmallBufferSize,(void*)(parserInfo.text + numberStart), sizeof(char) * (numberEnd - numberStart));
 				smallBuffer[numberEnd - numberStart] = '\0';
 				// TODO: atof is not safe use a safer modern alternative
 				*out = (float)atof(smallBuffer);

--- a/Animations/src/parsers/Grammar.cpp
+++ b/Animations/src/parsers/Grammar.cpp
@@ -1009,16 +1009,14 @@ namespace MathAnim
 			}
 			grammar->region = nullptr;
 
-			grammar->~Grammar();
-			g_memory_free(grammar);
+			g_memory_delete(grammar);
 		}
 	}
 
 	// ----------- Internal Functions -----------
 	static Grammar* importGrammarFromJson(const json& j)
 	{
-		Grammar* res = (Grammar*)g_memory_allocate(sizeof(Grammar));
-		new(res)Grammar();
+		Grammar* res = g_memory_new Grammar();
 
 		res->region = onig_region_new();
 
@@ -1072,8 +1070,7 @@ namespace MathAnim
 
 	static SyntaxPattern* const parsePattern(const json& json, Grammar* self)
 	{
-		SyntaxPattern* const res = (SyntaxPattern*)g_memory_allocate(sizeof(SyntaxPattern));
-		new(res)SyntaxPattern();
+		SyntaxPattern* const res = g_memory_new SyntaxPattern();
 		res->type = PatternType::Invalid;
 		res->self = self;
 
@@ -1675,7 +1672,6 @@ namespace MathAnim
 	static void freePattern(SyntaxPattern* const pattern)
 	{
 		pattern->free();
-		pattern->~SyntaxPattern();
-		g_memory_free(pattern);
+		g_memory_delete(pattern);
 	}
 }

--- a/Animations/src/parsers/SyntaxHighlighter.cpp
+++ b/Animations/src/parsers/SyntaxHighlighter.cpp
@@ -119,8 +119,7 @@ namespace MathAnim
 			{
 				if (Platform::fileExists(_highlighterLanguageFilenames[i]))
 				{
-					SyntaxHighlighter* highlighter = (SyntaxHighlighter*)g_memory_allocate(sizeof(SyntaxHighlighter));
-					new(highlighter)SyntaxHighlighter(_highlighterLanguageFilenames[i]);
+					SyntaxHighlighter* highlighter = g_memory_new SyntaxHighlighter(_highlighterLanguageFilenames[i]);
 					grammars[(HighlighterLanguage)i] = highlighter;
 				}
 			}
@@ -163,8 +162,7 @@ namespace MathAnim
 			for (auto [k, v] : grammars)
 			{
 				v->free();
-				v->~SyntaxHighlighter();
-				g_memory_free(v);
+				g_memory_delete(v);
 			}
 			grammars.clear();
 

--- a/Animations/src/parsers/SyntaxTheme.cpp
+++ b/Animations/src/parsers/SyntaxTheme.cpp
@@ -283,8 +283,7 @@ namespace MathAnim
 	{
 		if (theme)
 		{
-			theme->~SyntaxTheme();
-			g_memory_free(theme);
+			g_memory_delete(theme);
 		}
 	}
 
@@ -303,8 +302,7 @@ namespace MathAnim
 			g_logger_warning("Syntax theme is malformed. The property 'tokenColors' is not an array in file: '{}'", filepath);
 		}
 
-		SyntaxTheme* theme = (SyntaxTheme*)g_memory_allocate(sizeof(SyntaxTheme));
-		new(theme)SyntaxTheme();
+		SyntaxTheme* theme = g_memory_new SyntaxTheme();
 
 		if (j.contains("colors"))
 		{
@@ -488,8 +486,7 @@ namespace MathAnim
 			return nullptr;
 		}
 
-		SyntaxTheme* theme = (SyntaxTheme*)g_memory_allocate(sizeof(SyntaxTheme));
-		new(theme)SyntaxTheme();
+		SyntaxTheme* theme = g_memory_new SyntaxTheme();
 
 		const XMLElement* setting = arrayElement->FirstChildElement();
 		while (setting != nullptr)

--- a/Animations/src/renderer/Fonts.cpp
+++ b/Animations/src/renderer/Fonts.cpp
@@ -288,7 +288,8 @@ namespace MathAnim
 				.generateEmpty();
 
 			// Generate the texture and upload it to the GPU
-			uint8* textureMemory = (uint8*)g_memory_allocate(sizeof(uint8) * textureWidth * textureHeight);
+			size_t textureMemorySize = sizeof(uint8) * textureWidth * textureHeight;
+			uint8* textureMemory = (uint8*)g_memory_allocate(textureMemorySize);
 			g_memory_zeroMem(textureMemory, sizeof(uint8) * textureWidth * textureHeight);
 			uint32 cursorX = 0;
 			uint32 cursorY = 0;
@@ -329,7 +330,8 @@ namespace MathAnim
 				{
 					uint8* dst = textureMemory + cursorX + ((cursorY + y) * textureWidth);
 					uint8* src = bitmap.buffer + (y * bitmap.width);
-					g_memory_copyMem(dst, src, sizeof(uint8) * bitmap.width);
+					size_t textureMemorySizeLeft = textureMemorySize - (dst - textureMemory);
+					g_memory_copyMem(dst, textureMemorySizeLeft, src, sizeof(uint8) * bitmap.width);
 				}
 
 				// Add normalized glyph position
@@ -796,7 +798,7 @@ namespace MathAnim
 				freeBuffer = true;
 			}
 
-			g_memory_copyMem(buffer, (void*)filepath, sizeof(char) * filepathSize);
+			g_memory_copyMem(buffer, sizeof(char) * filepathSize + 1, (void*)filepath, sizeof(char) * filepathSize);
 			buffer[filepathSize] = '\0';
 
 			for (int i = 0; i < filepathSize; i++)

--- a/Animations/src/renderer/PixelBufferDownloader.cpp
+++ b/Animations/src/renderer/PixelBufferDownloader.cpp
@@ -109,7 +109,7 @@ namespace MathAnim
 		uint8* gpuPixelData = (uint8*)GL::mapBuffer(GL_PIXEL_PACK_BUFFER, GL_READ_ONLY);
 		if (gpuPixelData)
 		{
-			g_memory_copyMem(this->currentOutputPixels.yColorBuffer, gpuPixelData, this->data->pboSize);
+			g_memory_copyMem(this->currentOutputPixels.yColorBuffer, this->data->pboSize, gpuPixelData, this->data->pboSize);
 		}
 		else
 		{

--- a/Animations/src/renderer/Renderer.cpp
+++ b/Animations/src/renderer/Renderer.cpp
@@ -1019,8 +1019,7 @@ namespace MathAnim
 		// ----------- 2D Line stuff ----------- 
 		Path2DContext* beginPath(const Vec2& start, const glm::mat4& transform)
 		{
-			Path2DContext* context = (Path2DContext*)g_memory_allocate(sizeof(Path2DContext));
-			new(context)Path2DContext();
+			Path2DContext* context = g_memory_new Path2DContext();
 
 			float strokeWidth = strokeWidthStackPtr > 0
 				? strokeWidthStack[strokeWidthStackPtr - 1]
@@ -1039,8 +1038,7 @@ namespace MathAnim
 
 		void free(Path2DContext* path)
 		{
-			path->~Path2DContext();
-			g_memory_free(path);
+			g_memory_delete(path);
 		}
 
 		static Vec3 transformVertVec3(const Vec2& vert, const glm::mat4& transform)

--- a/Animations/src/renderer/Renderer.cpp
+++ b/Animations/src/renderer/Renderer.cpp
@@ -836,7 +836,7 @@ namespace MathAnim
 		}
 
 		// ----------- 2D stuff ----------- 
-		void drawSquare(const Vec2& start, const Vec2& size)
+		void drawSquare(const Vec2& start, const Vec2& size, const glm::mat4& transform)
 		{
 			// Don't draw squares with non-negative sizes since that's an invalid input
 			if (size.x <= 0.0f || size.y <= 0.0f)
@@ -844,7 +844,7 @@ namespace MathAnim
 				return;
 			}
 
-			Path2DContext* path = beginPath(start);
+			Path2DContext* path = beginPath(start, transform);
 			lineTo(path, start + Vec2{ size.x, 0 });
 			lineTo(path, start + size);
 			lineTo(path, start + Vec2{ 0, size.y });

--- a/Animations/src/renderer/Renderer.cpp
+++ b/Animations/src/renderer/Renderer.cpp
@@ -1249,7 +1249,7 @@ namespace MathAnim
 						Renderer::pushColor(path->data[curvei].color);
 						if (currentT >= startT)
 						{
-							context = Renderer::beginPath(path->rawCurves[curvei].p0);
+							context = Renderer::beginPath(path->rawCurves[curvei].p0, path->transform);
 						}
 						else if (currentT + approxLengthTVal >= startT)
 						{
@@ -1259,7 +1259,7 @@ namespace MathAnim
 							approxLength = curve.calculateApproximatePerimeter();
 							approxLengthTVal = approxLength / (float)path->approximateLength;
 
-							context = Renderer::beginPath(curve.p0);
+							context = Renderer::beginPath(curve.p0, path->transform);
 						}
 						Renderer::popColor();
 					}

--- a/Animations/src/scripting/LuauLayer.cpp
+++ b/Animations/src/scripting/LuauLayer.cpp
@@ -53,8 +53,7 @@ namespace MathAnim
 			ScriptApi::registerGlobalFunctions(luaState, am);
 			scriptDirectory = inScriptDirectory;
 
-			analyzer = (ScriptAnalyzer*)g_memory_allocate(sizeof(ScriptAnalyzer));
-			new(analyzer)ScriptAnalyzer(inScriptDirectory);
+			analyzer = g_memory_new ScriptAnalyzer(inScriptDirectory);
 		}
 
 		void update()
@@ -296,8 +295,7 @@ namespace MathAnim
 			if (analyzer)
 			{
 				analyzer->free();
-				analyzer->~ScriptAnalyzer();
-				g_memory_free(analyzer);
+				g_memory_delete(analyzer);
 			}
 
 			if (luaState)

--- a/Animations/src/scripting/ScriptAnalyzer.cpp
+++ b/Animations/src/scripting/ScriptAnalyzer.cpp
@@ -60,12 +60,9 @@ namespace MathAnim
 		Luau::FrontendOptions frontendOptions;
 		frontendOptions.retainFullTypeGraphs = false;
 
-		fileResolver = (ScriptFileResolver*)g_memory_allocate(sizeof(ScriptFileResolver));
-		new(fileResolver)ScriptFileResolver(scriptDirectory);
-		configResolver = (ScriptConfigResolver*)g_memory_allocate(sizeof(ScriptConfigResolver));
-		new(configResolver)ScriptConfigResolver();
-		frontend = (Luau::Frontend*)g_memory_allocate(sizeof(Luau::Frontend));
-		new(frontend)Luau::Frontend(fileResolver, configResolver, frontendOptions);
+		fileResolver = g_memory_new ScriptFileResolver(scriptDirectory);
+		configResolver = g_memory_new ScriptConfigResolver();
+		frontend = g_memory_new Luau::Frontend(fileResolver, configResolver, frontendOptions);
 
 		// Register the bundled builtin globals that come with Luau
 		Luau::registerBuiltinGlobals(frontend->typeChecker);
@@ -188,23 +185,9 @@ namespace MathAnim
 
 	void ScriptAnalyzer::free()
 	{
-		if (fileResolver)
-		{
-			fileResolver->~FileResolver();
-			g_memory_free(fileResolver);
-		}
-
-		if (configResolver)
-		{
-			configResolver->~ConfigResolver();
-			g_memory_free(configResolver);
-		}
-
-		if (frontend)
-		{
-			frontend->~Frontend();
-			g_memory_free(frontend);
-		}
+		g_memory_delete(fileResolver);
+		g_memory_delete(configResolver);
+		g_memory_delete(frontend);
 
 		fileResolver = nullptr;
 		configResolver = nullptr;

--- a/Animations/src/svg/Svg.cpp
+++ b/Animations/src/svg/Svg.cpp
@@ -1963,6 +1963,9 @@ namespace MathAnim
 
 	void SvgGroup::calculateBBox()
 	{
+		bbox.min = { FLT_MAX, FLT_MAX };
+		bbox.max = { -FLT_MAX, -FLT_MAX };
+
 		for (int i = 0; i < numObjects; i++)
 		{
 			SvgObject& obj = objects[i];
@@ -1981,8 +1984,9 @@ namespace MathAnim
 			obj.calculateSize();
 			bbox.min = CMath::min(obj.bbox.min + absOffset, bbox.min);
 			bbox.max = CMath::max(obj.bbox.max + absOffset, bbox.max);
-			size = CMath::max(bbox.max - bbox.min, size);
 		}
+
+		size = bbox.max - bbox.min;
 	}
 
 	void SvgGroup::free()

--- a/Animations/src/svg/Svg.cpp
+++ b/Animations/src/svg/Svg.cpp
@@ -102,7 +102,7 @@ namespace MathAnim
 				group->uniqueObjects[group->numUniqueObjects - 1] = Svg::createDefault();
 				Svg::copy(group->uniqueObjects + (group->numUniqueObjects - 1), &obj);
 				group->uniqueObjectNames[group->numUniqueObjects - 1] = (char*)g_memory_allocate(sizeof(char) * (id.length() + 1));
-				g_memory_copyMem(group->uniqueObjectNames[group->numUniqueObjects - 1], (void*)id.c_str(), id.length() * sizeof(char));
+				g_memory_copyMem(group->uniqueObjectNames[group->numUniqueObjects - 1], sizeof(char) * (id.length() + 1), (void*)id.c_str(), id.length() * sizeof(char));
 				group->uniqueObjectNames[group->numUniqueObjects - 1][id.length()] = '\0';
 			}
 		}
@@ -595,7 +595,7 @@ namespace MathAnim
 			if (dest->md5Length > 0)
 			{
 				dest->md5 = (uint8*)g_memory_realloc(dest->md5, sizeof(uint8) * (src->md5Length + 1));
-				g_memory_copyMem(dest->md5, (void*)src->md5, sizeof(uint8) * (src->md5Length + 1));
+				g_memory_copyMem(dest->md5, sizeof(uint8) * (src->md5Length + 1), (void*)src->md5, sizeof(uint8) * (src->md5Length + 1));
 			}
 			else
 			{
@@ -1474,7 +1474,7 @@ namespace MathAnim
 		std::string md5Str = Platform::md5FromString((const char*)b64Path.data, b64Path.size - 1);
 		md5Length = md5Str.length();
 		md5 = (uint8*)g_memory_allocate(sizeof(uint8) * (md5Length + 1));
-		g_memory_copyMem(md5, (void*)md5Str.c_str(), sizeof(uint8) * md5Length);
+		g_memory_copyMem(md5, sizeof(uint8) * (md5Length + 1), (void*)md5Str.c_str(), sizeof(uint8) * md5Length);
 		md5[md5Length] = '\0';
 	}
 
@@ -2459,14 +2459,18 @@ namespace MathAnim
 		}
 
 		growBufferIfNeeded(buffer, capacity, *numElements, stringLength);
-		g_memory_copyMem(*buffer + *numElements, (void*)string, stringLength * sizeof(uint8));
+		uint8* dst = *buffer + *numElements;
+		size_t sizeLeft = *capacity - (dst - *buffer);
+		g_memory_copyMem(*buffer + *numElements, sizeLeft, (void*)string, stringLength * sizeof(uint8));
 		*numElements += stringLength;
 	}
 
 	static void writeBufferBin(uint8** buffer, size_t* capacity, size_t* numElements, const uint8* data, size_t numBytes)
 	{
 		growBufferIfNeeded(buffer, capacity, *numElements, numBytes);
-		g_memory_copyMem(*buffer + *numElements, (void*)data, numBytes * sizeof(uint8));
+		uint8* dst = *buffer + *numElements;
+		size_t sizeLeft = *capacity - (dst - *buffer);
+		g_memory_copyMem(*buffer + *numElements, sizeLeft, (void*)data, numBytes * sizeof(uint8));
 		*numElements += numBytes;
 	}
 }

--- a/Animations/src/svg/Svg.cpp
+++ b/Animations/src/svg/Svg.cpp
@@ -39,8 +39,7 @@ namespace MathAnim
 			// TODO: Fix the dang memory allocation library so I don't have to do this!
 			res.paths = (Path*)g_memory_allocate(sizeof(Path));
 			res.numPaths = 0;
-			res.bbox.min = Vec2{ 0, 0 };
-			res.bbox.max = Vec2{ 0, 0 };
+			res.size = Vec2{ 0, 0 };
 			res._cursor = Vec2{ 0, 0 };
 			res.fillColor = Vec4{ 1, 1, 1, 1 };
 			res.fillType = FillType::NonZeroFillType;
@@ -589,6 +588,7 @@ namespace MathAnim
 			dest->fillType = src->fillType;
 			dest->fillColor = src->fillColor;
 			dest->approximatePerimeter = src->approximatePerimeter;
+			dest->size = src->size;
 			dest->bbox = src->bbox;
 
 			dest->md5Length = src->md5Length;
@@ -1421,7 +1421,7 @@ namespace MathAnim
 		}
 	}
 
-	void SvgObject::calculateBBox()
+	void SvgObject::calculateSize()
 	{
 		bbox.min.x = FLT_MAX;
 		bbox.min.y = FLT_MAX;
@@ -1465,6 +1465,8 @@ namespace MathAnim
 				}
 			}
 		}
+
+		this->size = bbox.max - bbox.min;
 	}
 
 	void SvgObject::calculateMd5(const RawMemory& b64Path)
@@ -1479,7 +1481,7 @@ namespace MathAnim
 	void SvgObject::finalize()
 	{
 		this->calculateApproximatePerimeter();
-		this->calculateBBox();
+		this->calculateSize();
 		RawMemory b64String = getPathAsBinaryString();
 		this->calculateMd5(b64String);
 		b64String.free();
@@ -1488,14 +1490,14 @@ namespace MathAnim
 	void SvgObject::finalizeWithB64(const RawMemory& b64Path)
 	{
 		this->calculateApproximatePerimeter();
-		this->calculateBBox();
+		this->calculateSize();
 		this->calculateMd5(b64Path);
 	}
 
 	void SvgObject::finalizeWithB64(const std::string& b64String) 
 	{
 		this->calculateApproximatePerimeter();
-		this->calculateBBox();
+		this->calculateSize();
 
 		RawMemory fakeMemory = {};
 		fakeMemory.data = (uint8*)b64String.c_str();
@@ -1665,7 +1667,7 @@ namespace MathAnim
 
 	float SvgObject::calculateSvgScale(float targetWidth) const
 	{
-		float maxSize = glm::max(CMath::abs(bbox.max.x - bbox.min.x), CMath::abs(bbox.max.y - bbox.min.y));
+		float maxSize = glm::max(size.x, size.y);
 		if (maxSize != 0.0f)
 		{
 			return targetWidth / maxSize;
@@ -1677,7 +1679,7 @@ namespace MathAnim
 	void SvgObject::render(float svgScale, const Texture& texture, const Vec2& textureOffset) const
 	{
 		MP_PROFILE_EVENT("Svg_RenderWithPluto");
-		Vec2 bboxSize = (bbox.max - bbox.min) * svgScale;
+		Vec2 bboxSize = size * svgScale;
 
 		// Setup pluto context to render SVG to
 		plutovg_surface_t* surface = plutovg_surface_create((int)bboxSize.x, (int)bboxSize.y);
@@ -1866,7 +1868,6 @@ namespace MathAnim
 	{
 		calculateBBox();
 
-		Vec2 svgGroupSize = bbox.max - bbox.min;
 		for (int i = 0; i < numObjects; i++)
 		{
 			SvgObject& obj = objects[i];
@@ -1876,10 +1877,10 @@ namespace MathAnim
 
 			// Map everything to [0.0, 1.0] range except it needs to be scaled
 			// relative to the size in the overall svg group
-			Vec2 hzInputRange = Vec2{ obj.bbox.min.x, obj.bbox.max.x };
-			Vec2 vtInputRange = Vec2{ obj.bbox.min.y, obj.bbox.max.y };
-			float outputWidth = (obj.bbox.max.x - obj.bbox.min.x) / svgGroupSize.x;
-			float outputHeight = (obj.bbox.max.y - obj.bbox.min.y) / svgGroupSize.y * (svgGroupSize.y / svgGroupSize.x);
+			Vec2 hzInputRange = Vec2{ 0.0f, obj.size.x };
+			Vec2 vtInputRange = Vec2{ 0.0f, obj.size.y };
+			float outputWidth = obj.size.x / size.x;
+			float outputHeight = obj.size.y / size.y * (size.y / size.x);
 			Vec2 hzOutputRange = Vec2{ 0.0f, outputWidth };
 			Vec2 vtOutputRange = Vec2{ 0.0f, outputHeight };
 			for (int pathi = 0; pathi < obj.numPaths; pathi++)
@@ -1927,11 +1928,11 @@ namespace MathAnim
 
 			Vec2 originalBboxMin = obj.bbox.min;
 			// Calculate the boundaries using the new ranges
-			obj.calculateBBox();
+			obj.calculateSize();
 			obj.calculateApproximatePerimeter();
 
 			float outputGroupWidth = 1.0f;
-			float outputGroupHeight = (svgGroupSize.y / svgGroupSize.x);
+			float outputGroupHeight = (size.y / size.x);
 
 			// If no offset was provided, then just use the minimum
 			// coordinates as the natural offset
@@ -1945,25 +1946,23 @@ namespace MathAnim
 				offset.y = originalBboxMin.y;
 			}
 
-			offset.x = CMath::mapRange(Vec2{ this->bbox.min.x, this->bbox.max.x }, Vec2{ 0.0f, outputGroupWidth }, offset.x);
-			offset.y = CMath::mapRange(Vec2{ this->bbox.min.y, this->bbox.max.y }, Vec2{ 0.0f, outputGroupHeight }, offset.y);
+			offset.x = CMath::mapRange(Vec2{ 0.0f, this->size.x }, Vec2{ 0.0f, outputGroupWidth }, offset.x);
+			offset.y = CMath::mapRange(Vec2{ 0.0f, this->size.y }, Vec2{ 0.0f, outputGroupHeight }, offset.y);
 			offset.y = outputGroupHeight - offset.y;
 			Vec2 centerOffset = Vec2{
-				(obj.bbox.max.x - obj.bbox.min.x) / 2.0f,
-				-(obj.bbox.max.y - obj.bbox.min.y) / 2.0f
+				obj.size.x / 2.0f,
+				-obj.size.y / 2.0f
 			};
 			offset += centerOffset;
 			// Center the whole object
 			offset -= Vec2{ outputGroupWidth / 2.0f, outputGroupHeight / 2.0f };
 		}
+
 		calculateBBox();
 	}
 
 	void SvgGroup::calculateBBox()
 	{
-		bbox.min = Vec2{ NAN, NAN };
-		bbox.max = Vec2{ NAN, NAN };
-
 		for (int i = 0; i < numObjects; i++)
 		{
 			SvgObject& obj = objects[i];
@@ -1979,9 +1978,10 @@ namespace MathAnim
 				absOffset.y = 0.0f;
 			}
 
-			obj.calculateBBox();
+			obj.calculateSize();
 			bbox.min = CMath::min(obj.bbox.min + absOffset, bbox.min);
 			bbox.max = CMath::max(obj.bbox.max + absOffset, bbox.max);
+			size = CMath::max(bbox.max - bbox.min, size);
 		}
 	}
 
@@ -2039,10 +2039,10 @@ namespace MathAnim
 		g_logger_assert(dataSize == sizeof(RenderAsyncData), "Invalid data passed to renderAsyncCallback");
 
 		RenderAsyncData* data = (RenderAsyncData*)renderAsyncData;
-		Vec2 bboxSize = (data->obj->bbox.max - data->obj->bbox.min) * data->svgScale;
+		Vec2 scaledSize = data->obj->size * data->svgScale;
 
 		// Setup pluto context to render SVG to
-		plutovg_surface_t* surface = plutovg_surface_create((int)bboxSize.x, (int)bboxSize.y);
+		plutovg_surface_t* surface = plutovg_surface_create((int)scaledSize.x, (int)scaledSize.y);
 		plutovg_t* pluto = plutovg_create(surface);
 		data->surface = surface;
 		data->pluto = pluto;
@@ -2092,11 +2092,8 @@ namespace MathAnim
 		Vec2 inXRange = Vec2{ obj->bbox.min.x, obj->bbox.max.x };
 		Vec2 inYRange = Vec2{ obj->bbox.min.y, obj->bbox.max.y };
 
-		Vec2 bboxSize = obj->bbox.max - obj->bbox.min;
-		Vec2 minCoord = Vec2{ 0, 0 };
-		Vec2 maxCoord = minCoord + (bboxSize * scale);
-		Vec2 outXRange = Vec2{ minCoord.x, maxCoord.x };
-		Vec2 outYRange = Vec2{ minCoord.y, maxCoord.y };
+		Vec2 outXRange = Vec2{ 0.0f, obj->size.x * scale };
+		Vec2 outYRange = Vec2{ 0.0f, obj->size.y * scale };
 
 		plutovg_new_path(pluto);
 
@@ -2206,12 +2203,11 @@ namespace MathAnim
 
 		// Start the fade in after 80% of the svg object is drawn
 		float lengthToDraw = t * (float)obj->approximatePerimeter;
-		Vec2 svgSize = obj->bbox.max - obj->bbox.min;
 
 		Vec2 inXRange = Vec2{ obj->bbox.min.x, obj->bbox.max.x };
 		Vec2 inYRange = Vec2{ obj->bbox.min.y, obj->bbox.max.y };
-		Vec2 outXRange = Vec2{ -svgSize.x / 2.0f, svgSize.x / 2.0f };
-		Vec2 outYRange = Vec2{ svgSize.y / 2.0f, -svgSize.y / 2.0f };
+		Vec2 outXRange = Vec2{ -obj->size.x / 2.0f, obj->size.x / 2.0f };
+		Vec2 outYRange = Vec2{ obj->size.y / 2.0f, -obj->size.y / 2.0f };
 
 		if (lengthToDraw > 0 && obj->numPaths > 0)
 		{

--- a/Animations/src/svg/SvgCache.cpp
+++ b/Animations/src/svg/SvgCache.cpp
@@ -93,8 +93,8 @@ namespace MathAnim
 			int colorAttachmentToRenderTo = this->cacheCurrentColorAttachment;
 
 			// Check if the SVG cache needs to regenerate
-			float svgTotalWidth = ((svg->bbox.max.x - svg->bbox.min.x) * parent->svgScale);
-			float svgTotalHeight = ((svg->bbox.max.y - svg->bbox.min.y) * parent->svgScale);
+			float svgTotalWidth = (svg->size.x * parent->svgScale);
+			float svgTotalHeight = (svg->size.y * parent->svgScale);
 			if (svgTotalWidth <= 0.0f || svgTotalHeight <= 0.0f)
 			{
 				return;
@@ -239,15 +239,12 @@ namespace MathAnim
 		if (parent)
 		{
 			SvgCacheEntry metadata = getOrCreateIfNotExist(am, svg, obj);
-			// TODO: See if I can get rid of this duplication, see the function above
-			float svgTotalWidth = ((svg->bbox.max.x - svg->bbox.min.x) * parent->svgScale);
-			float svgTotalHeight = ((svg->bbox.max.y - svg->bbox.min.y) * parent->svgScale);
 
 			// Everything is 3D now... Good or bad? Who knows?
 			Renderer::pushColor(parent->fillColor);
 			Renderer::drawTexturedQuad3D(
 				metadata.textureRef,
-				Vec2{ svgTotalWidth / parent->svgScale, svgTotalHeight / parent->svgScale },
+				svg->size,
 				metadata.texCoordsMin,
 				metadata.texCoordsMax,
 				parent->id,

--- a/Animations/src/svg/SvgParser.cpp
+++ b/Animations/src/svg/SvgParser.cpp
@@ -397,7 +397,7 @@ namespace MathAnim
 							std::string idStr = std::string(id->Value());
 							auto iter = objIds.find(idStr);
 							g_logger_assert(iter == objIds.end(), "Tried to insert duplicate ID '{}' in SVG object map", idStr);
-							obj.calculateBBox();
+							obj.calculateSize();
 							objIds[idStr] = obj;
 						}
 					}
@@ -489,7 +489,8 @@ namespace MathAnim
 							// the bottom-left
 							// NOTE: I'm not exactly sure why I have to "flip" the coordinate like this
 							// but it works and that's good enough for me...
-							y = y + iter->second.bbox.min.y - viewbox.values[3];
+							//y = y + iter->second.bbox.min.y - viewbox.values[3];
+							y = y - viewbox.values[3];
 							Svg::pushSvgToGroup(group, iter->second, iter->first, Vec2{ x, y });
 						}
 					}

--- a/Animations/src/svg/SvgParser.cpp
+++ b/Animations/src/svg/SvgParser.cpp
@@ -112,7 +112,7 @@ namespace MathAnim
 			DumbString res = {};
 			res.text = (char*)g_memory_allocate(sizeof(char) * (textLength + 1));
 			res.textLength = textLength;
-			g_memory_copyMem(res.text, text, (textLength + 1) * sizeof(char));
+			g_memory_copyMem(res.text, sizeof(char) * (textLength + 1), text, (textLength + 1) * sizeof(char));
 			return res;
 		}
 
@@ -2118,7 +2118,7 @@ namespace MathAnim
 
 			string->textLength = (stringEndIndex - stringStartIndex);
 			string->text = (char*)g_memory_allocate(sizeof(char) * (string->textLength + 1));
-			g_memory_copyMem(string->text, (void*)(parserInfo.text + stringStartIndex), sizeof(char) * string->textLength);
+			g_memory_copyMem(string->text, sizeof(char) * (string->textLength + 1), (void*)(parserInfo.text + stringStartIndex), sizeof(char) * string->textLength);
 			string->text[string->textLength] = '\0';
 
 			return true;
@@ -2157,7 +2157,7 @@ namespace MathAnim
 
 			string->textLength = (stringEndIndex - stringStartIndex);
 			string->text = (char*)g_memory_allocate(sizeof(char) * (string->textLength + 1));
-			g_memory_copyMem(string->text, (void*)(parserInfo.text + stringStartIndex), sizeof(char) * string->textLength);
+			g_memory_copyMem(string->text, sizeof(char) * (string->textLength + 1), (void*)(parserInfo.text + stringStartIndex), sizeof(char) * string->textLength);
 			string->text[string->textLength] = '\0';
 
 			return true;


### PR DESCRIPTION
This fixes a few broken animations:

* Image Objects
  * Additionally, error messages appear if it can't load an image
* Bounding box animations (Circumscribe)
* SVG file objects
* 3D Move To Animation

It also fixes a few bugs in regards to weird updates while moving the timeline cursor, and adds visualizations when moving objects using hot-keys (g to move).